### PR TITLE
chore: change dependabot update schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,21 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "build"
       include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "ci"
       include: "scope"
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to adjust the update schedules for various package ecosystems from weekly to monthly.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R20): Changed the update interval for `npm`, `github-actions`, and `devcontainers` package ecosystems from "weekly" to "monthly" to reduce the frequency of automated dependency updates.