### PR TITLE
fix: correct default branch reference in GitHub Actions workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/static.yml` file. The change updates the branch configuration for the workflow to target `main` instead of `$default-branch`.