### PR TITLE
fix: correct variable reference for analytics injection in workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Inject analytics tags
-        if: ${{ env.INJECT_ANALYTICS == 'true' }}
+        if: ${{ vars.INJECT_ANALYTICS == 'true' }}
         run: node .github/workflows/inject_analytics.js
       - name: Remove unnecessary files
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/static.yml` file. The change updates the conditional check for injecting analytics tags to use `vars` instead of `env`.