### PR TITLE
chore: add ignore rule for major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to improve dependency management by ignoring major version updates for all dependencies.

Key change to dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R12): Added an `ignore` section to exclude major version updates (`version-update:semver-major`) for all dependencies (`dependency-name: "*"`) to prevent breaking changes from being automatically applied.