### PR TITLE
chore: add permissions section to Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,9 @@ on:
     - cron: "18 18 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by explicitly setting the required permissions for the workflow. This helps improve security by restricting the workflow's access to repository contents.

- Added explicit `permissions` for the workflow, allowing only read access to repository contents in `.github/workflows/playwright.yml`.