### PR TITLE
build: upgrade pnpm to version 11

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
-          version: 10
+          version: 11
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "package.json"
           cache: "pnpm"
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm ci
       - name: Build project
         if: github.event_name == 'pull_request'
         run: pnpm run build

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
-          version: 10
+          version: 11
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "package.json"
           cache: "pnpm"
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm ci
       - name: Build project
         run: pnpm run build
       - name: Inject analytics tags

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "24"
-pnpm = "10"
+pnpm = "11"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "packageManager": [
       {
         "name": "pnpm",
-        "version": "^10"
+        "version": "^11"
       }
     ]
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,1 @@
-minimumReleaseAge: 1440
 trustPolicy: no-downgrade


### PR DESCRIPTION
This pull request updates the project to use pnpm version 11 across all configuration files and CI workflows, ensuring consistency in the development environment and build processes. It also switches CI dependency installation commands from `pnpm install` to the more reliable `pnpm ci`.

**Dependency management upgrades:**

* Updated pnpm version from 10 to 11 in `mise.toml` and `package.json`, ensuring local and package-managed environments use the latest major version. [[1]](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R41)

**CI workflow improvements:**

* Updated the pnpm setup step to use version 11 in both `.github/workflows/playwright.yml` and `.github/workflows/static.yml`. [[1]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L23-R30) [[2]](diffhunk://#diff-33f2778a5bb1ccf0ce7a73eeeeb02daf6023c2bdb47ff841fcf782fc3e469404L36-R43)
* Changed the dependency installation command from `pnpm install` to `pnpm ci` in CI workflows for more deterministic and reproducible builds. [[1]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L23-R30) [[2]](diffhunk://#diff-33f2778a5bb1ccf0ce7a73eeeeb02daf6023c2bdb47ff841fcf782fc3e469404L36-R43)

**Other:**

* No significant changes in `pnpm-workspace.yaml` aside from a line removal, which does not affect functionality.