### PR TITLE
chore: set open-pull-requests-limit to 10 in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 1
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
       include: "scope"


### PR DESCRIPTION
This pull request makes a small configuration change to the Dependabot settings. The change increases the maximum number of open pull requests Dependabot can create at one time to 10.