### PR TITLE
chore: remove VS Code workspace configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["github.vscode-github-actions", "ms-playwright.playwright", "oxc.oxc-vscode"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "oxc.oxc-vscode",
-  "oxc.fmt.configPath": ".oxfmtrc.json"
-}


### PR DESCRIPTION
## Summary
- Remove VS Code extension recommendations
- Remove workspace-specific editor formatting settings

## Testing
- Not run (not requested)